### PR TITLE
add/GPSttyACM

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,10 @@ docker run \
 	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
 	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
 	--device /dev/input/js0:/dev/input/js0:mwr \
+	--device /dev/ttyACM0:/dev/ttyACM0:mwr \
+	--device /dev/ttyACM1:/dev/ttyACM1:mwr \
+	--device /dev/ttyACM2:/dev/ttyACM2:mwr \
 	igvc2023
 	
+	#--device /dev/sensors/LED:/dev/sensors/LED:mwr \
 	#-e RESOLUTION=1920x1080


### PR DESCRIPTION
## 概要

- GPSのttyACMの追加をする(３つ)
- 3つともidVendorとidProduct同じなためttyACMの名前変更はしてません

### なぜこのタスクを行うのか

- robot_localizationのGPSが使えるようにする
- 後にGPSを2つ使ってmovingbaseをすることと、CLASを使うために３つttyACMを追加

